### PR TITLE
Improvements and bug fixes

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1,10 +1,26 @@
-const { PREFIX, TOKEN } = require("./config.js");
+const { TOKEN } = require("./config.js");
 const fs = require("fs");
 const path = require("node:path");
 const { Client, Events, Collection, GatewayIntentBits } = require("discord.js");
+const { testConnection } = require("./db");
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 client.commands = new Collection();
+
+client.sendToOatmeals = async (interaction, chatMessage) => {
+    const ownerId = process.env.OWNER_ID;
+    if (!ownerId) {
+        console.warn('OWNER_ID not set — cannot send error report');
+        return;
+    }
+    try {
+        await interaction.client.users.send(ownerId,
+            `Message: ${chatMessage}\nUsername: ${interaction.user}\nGuild: ${interaction.guild}\nGuildID: ${interaction.guild.id}\nInteraction: ${interaction}`
+        );
+    } catch (err) {
+        console.log(`Error sending to owner: ${err}`);
+    }
+};
 
 const commandFolder = fs.readdirSync("./commands");
 
@@ -40,4 +56,5 @@ for (const file of eventFiles) {
     }
 }
 
+testConnection();
 client.login(TOKEN);

--- a/commands/fun/8ball.js
+++ b/commands/fun/8ball.js
@@ -1,6 +1,6 @@
 const { request } = require("undici");
 const { SlashCommandBuilder } = require("discord.js");
-const { updateUserAction } = require('../../db'); 
+const { updateUserAction } = require('../../db');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -15,14 +15,11 @@ module.exports = {
                 .setRequired(true)
         ),
     async execute(interaction) {
+        await interaction.deferReply();
         const question = interaction.options.getString("question");
-
         const questionURL = await request("https://www.eightballapi.com/api");
         const { reading } = await questionURL.body.json();
-        await interaction.reply(
-            `Question: ${question} \n Answer: ${reading}`
-        );
+        await interaction.editReply(`Question: ${question} \n Answer: ${reading}`);
         await updateUserAction(interaction.user.id, interaction.user.username, 'eightball_asked');
-
     },
 };

--- a/commands/fun/dad.js
+++ b/commands/fun/dad.js
@@ -1,6 +1,6 @@
 const { request } = require("undici");
 const { SlashCommandBuilder } = require("discord.js");
-const { updateUserAction } = require('../../db'); 
+const { updateUserAction } = require('../../db');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -8,12 +8,11 @@ module.exports = {
         .setDescription(
             "I'm hungry. Hello Hungry I'm dad."
         ),
-      
     async execute(interaction) {
-        const dadJokeURL = await request("https://icanhazdadjoke.com", {headers: {Accept: "application/json"}});
-        const {joke}  = await dadJokeURL.body.json()
-        await interaction.reply(`${joke}`);
+        await interaction.deferReply();
+        const dadJokeURL = await request("https://icanhazdadjoke.com", { headers: { Accept: "application/json" } });
+        const { joke } = await dadJokeURL.body.json();
+        await interaction.editReply(`${joke}`);
         await updateUserAction(interaction.user.id, interaction.user.username, 'dadjoke_told');
-
     },
 };

--- a/commands/fun/insult.js
+++ b/commands/fun/insult.js
@@ -1,8 +1,7 @@
 const { request } = require("undici");
 const { SlashCommandBuilder } = require("discord.js");
-const { updateInteractionStats } = require('../../db'); 
+const { updateInteractionStats } = require('../../db');
 const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:5000';
-
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -12,29 +11,19 @@ module.exports = {
             option.setName("user").setDescription("Let's insult somebody...")
         ),
     async execute(interaction) {
-        const sender = interaction.user;
-        const insultURL = await request(
-            `${API_BASE_URL}/insult`
-        );
-        const body = await insultURL.body.json(); 
-        const insult = body.message; 
-        const target = interaction.options.getUser('user') || sender;
         await interaction.deferReply();
-
-        const message = await interaction.editReply(
-            `${
-                target
-            } ${insult}`
-        );
-        message.react("🔥");
-
-        await updateInteractionStats(
-            sender.id,
-            sender.username,
-            target.id,
-            target.username,
-            'insult'
-          );
-
+        const sender = interaction.user;
+        const target = interaction.options.getUser('user') || sender;
+        try {
+            const insultURL = await request(`${API_BASE_URL}/insult`);
+            const body = await insultURL.body.json();
+            const insult = body.message;
+            const message = await interaction.editReply(`${target} ${insult}`);
+            message.react("🔥");
+            await updateInteractionStats(sender.id, sender.username, target.id, target.username, 'insult');
+        } catch (err) {
+            await interaction.editReply('⚠️ Could not reach the insult API. Try again later. Message sent to developer');
+            interaction.client.sendToOatmeals(interaction, `Insult API error: ${err}`);
+        }
     },
 };

--- a/commands/fun/praise.js
+++ b/commands/fun/praise.js
@@ -1,6 +1,6 @@
 const { request } = require(`undici`);
 const { SlashCommandBuilder } = require(`discord.js`);
-const { updateInteractionStats } = require('../../db'); 
+const { updateInteractionStats } = require('../../db');
 const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:5000';
 
 module.exports = {
@@ -11,29 +11,19 @@ module.exports = {
             option.setName(`user`).setDescription(`Let's be nice to people`)
         ),
     async execute(interaction) {
-        const sender = interaction.user;
-        const insultURL = await request(
-            `${API_BASE_URL}/compliment`
-        );
-        const body = await insultURL.body.json(); 
-        const compliment = body.message; 
-        const target = interaction.options.getUser('user') ?? sender;
-
         await interaction.deferReply();
-
-        const message = await interaction.editReply(
-            `${
-                target
-            } ${compliment}`
-        );
-        message.react(`🙏`);
-
-        await updateInteractionStats(
-            sender.id,
-            sender.username,
-            target.id,
-            target.username,
-            'praise'
-          );
+        const sender = interaction.user;
+        const target = interaction.options.getUser('user') ?? sender;
+        try {
+            const praiseURL = await request(`${API_BASE_URL}/compliment`);
+            const body = await praiseURL.body.json();
+            const compliment = body.message;
+            const message = await interaction.editReply(`${target} ${compliment}`);
+            message.react(`🙏`);
+            await updateInteractionStats(sender.id, sender.username, target.id, target.username, 'praise');
+        } catch (err) {
+            await interaction.editReply('⚠️ Could not reach the praise API. Try again later. Message sent to developer');
+            interaction.client.sendToOatmeals(interaction, `Praise API error: ${err}`);
+        }
     },
 };

--- a/commands/utility/choose.js
+++ b/commands/utility/choose.js
@@ -13,11 +13,9 @@ module.exports = {
     async execute(interaction) {
         const choiceInput = interaction.options.getString("choices");
         const splitOptions = choiceInput.split(" or ");
-        const randomAnswer =
-            splitOptions[Math.floor(Math.random() * splitOptions.length)];
+        const randomAnswer = splitOptions[Math.floor(Math.random() * splitOptions.length)];
         await interaction.reply(
-            "```" + interaction.user.username + " asks: " + choiceInput + "```"
+            "```" + interaction.user.username + " asks: " + choiceInput + "```\n" + randomAnswer
         );
-        await interaction.channel.send(randomAnswer);
     },
 };

--- a/commands/utility/comment.js
+++ b/commands/utility/comment.js
@@ -12,9 +12,9 @@ module.exports = {
                 .setRequired(true)
                 .setDescription("Hey man can you add a random pokemon command?")
         ),
-    async execute(interaction, sendToOatmeals) {
+    async execute(interaction) {
         const userComment = interaction.options.getString("comment");
-        sendToOatmeals(`${userComment}`);
+        interaction.client.sendToOatmeals(interaction, userComment);
         await interaction.reply("Comment sent. Thank you");
     },
 };

--- a/db.js
+++ b/db.js
@@ -4,6 +4,9 @@ const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
 });
 
+const ALLOWED_FIELDS = new Set(['eightball_asked', 'moos_made', 'dadjoke_told', 'gif_posted']);
+const ALLOWED_PREFIXES = new Set(['insult', 'praise']);
+
 async function testConnection() {
   try {
     const result = await pool.query('SELECT to_regclass(\'public.user_stats\') AS table_exists;');
@@ -19,6 +22,9 @@ async function testConnection() {
 
 
 async function updateUserAction(userId, username, fieldPrefix) {
+  if (!ALLOWED_FIELDS.has(fieldPrefix)) {
+    throw new Error(`Invalid fieldPrefix: ${fieldPrefix}`);
+  }
   const countField = `${fieldPrefix}`;
   const timeField = `last_${fieldPrefix}`;
 
@@ -42,6 +48,9 @@ async function updateUserAction(userId, username, fieldPrefix) {
 
 
 async function updateInteractionStats(senderId, senderName, targetId, targetName, prefix) {
+  if (!ALLOWED_PREFIXES.has(prefix)) {
+    throw new Error(`Invalid prefix: ${prefix}`);
+  }
   const senderCount = `${prefix}_given`;
   const targetCount = `${prefix}_received`;
   const senderTime = `last_${prefix}_given`;

--- a/env.sample
+++ b/env.sample
@@ -1,5 +1,7 @@
 TOKEN=theToken
-PREFIX=!
+CLIENTID=yourDiscordAppClientId
+GUILDID=yourDiscordGuildId
 GIF_TOKEN=giphyToken
 DATABASE_URL=postgresURL
-DATABASE_KEY=KEYBOI
+API_BASE_URL=http://localhost:5000
+OWNER_ID=yourDiscordUserId

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -5,35 +5,17 @@ module.exports = {
     async execute(interaction) {
         if (!interaction.isChatInputCommand()) return;
 
-        const command = interaction.client.commands.get(
-            interaction.commandName
-        );
-        const sendToOatmeals = (chatMessage) => {
-            try {
-                interaction.client.users.send(
-                    "254838552960040960",
-                    `Message: ${chatMessage}
-                    Username: ${interaction.user}
-                    Guild: ${interaction.guild}
-                    GuildID: ${interaction.guild.id}
-                    Interaction: ${interaction}`
-                );
-            } catch (error) {
-                console.log(`Error sending to oatmeal: ${error}`);
-            }
-        };
+        const command = interaction.client.commands.get(interaction.commandName);
 
         if (!command) {
-            console.error(
-                `No command matching ${interaction.commandName} was found.`
-            );
+            console.error(`No command matching ${interaction.commandName} was found.`);
             return;
         }
 
         try {
-            await command.execute(interaction, sendToOatmeals);
+            await command.execute(interaction);
         } catch (error) {
-            sendToOatmeals(`InteractionCreate Error:  ${error}`);
+            interaction.client.sendToOatmeals(interaction, `InteractionCreate Error: ${error}`);
             interaction.user.send("Hmm something went wrong. Message sent to Developer");
             console.error(`Error executing ${interaction.commandName}`);
             console.error(error);

--- a/events/ready.js
+++ b/events/ready.js
@@ -1,14 +1,19 @@
-const { Events , ActivityType} = require("discord.js");
+const { Events, ActivityType } = require("discord.js");
 
 module.exports = {
     name: Events.ClientReady,
     once: true,
     execute(client) {
-        let serverCount = client.guilds.cache.size;
-        client.users.send("254838552960040960", `BotStart Up, ${serverCount} servers`);
+        const ownerId = process.env.OWNER_ID;
+        const serverCount = client.guilds.cache.size;
+        if (ownerId) {
+            client.users.send(ownerId, `BotStart Up, ${serverCount} servers`);
+        } else {
+            console.warn('OWNER_ID not set — skipping startup DM');
+        }
         console.log(`ayyyy sup playa, ${client.user.tag}`);
-
         client.user.setPresence({
             activities: [{ name: `you`, type: ActivityType.Watching }]
-          });    },
+        });
+    },
 };


### PR DESCRIPTION
 - db.js — Added field/prefix whitelists (ALLOWED_FIELDS, ALLOWED_PREFIXES) to prevent SQL injection via template-literal column names
  - env.sample — Added missing vars (CLIENTID, GUILDID, API_BASE_URL, OWNER_ID); removed unused PREFIX and DATABASE_KEY
  - bot.js — Moved sendToOatmeals onto client.sendToOatmeals(interaction, msg); added testConnection() call on startup; removed unused PREFIX import
  - events/interactionCreate.js — Removed inline sendToOatmeals definition and stopped passing it as a parameter to commands; now uses interaction.client.sendToOatmeals
  - events/ready.js — Replaced hardcoded owner ID with process.env.OWNER_ID; logs a warning if unset
  - commands/fun/8ball.js — Switched from reply() to deferReply() + editReply() to avoid Discord's 3-second timeout
  - commands/fun/dad.js — Same timeout fix as 8ball.js
  - commands/utility/choose.js — Combined two separate messages (reply + channel.send) into a single reply
  - commands/fun/insult.js — Added try/catch around API call with a user-facing error message on failure
  - commands/fun/praise.js — Same API error handling as insult.js
  - commands/utility/comment.js — Updated to call interaction.client.sendToOatmeals instead of the old passed-in parameter